### PR TITLE
Add a Helm Chart to deploy in K8s

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: codetogether
+description: A Helm chart to deploy CodeTogether server in a Kubernetes cluster.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "4.0.1"
+
+keywords:
+- collaborative
+- codetogether
+- programming
+
+home: https://github.com/crivaledaz/codetogether
+source: https://github.com/crivaledaz/codetogether/helm
+
+maintainers:
+  - name: Denis CLAVIER
+    email: clavierd@gmail.com

--- a/helm/LICENSE
+++ b/helm/LICENSE
@@ -1,0 +1,21 @@
+This Helm Chart has been implemented by Denis CLAVIER under the MIT license.
+
+Copyright (c) 2021 Denis CLAVIER
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/helm/Readme.md
+++ b/helm/Readme.md
@@ -1,0 +1,90 @@
+Helm Chart for CodeTogether Server (On Premises)
+================================================
+
+## Summary
+
+This chart creates a CodeTogether server deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+This chart has been created with Helm v3. To use it ensure the following prerequisites are fullfilled :
+
+- Kubernetes 1.9+
+- Helm v3
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm repo add crivaledaz http://clavier.iiens.net/helm
+$ helm install my-release crivaledaz/codetogether
+```
+
+The command deploys CodeTogether on the Kubernetes cluster in the default configuration. The configuration section lists parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists configurable parameters of the CodeTogether chart and their default values.
+
+| Parameter                    | Description                                                                   | Default                                         |
+| ---------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- |
+| `service.type`               | Service type                                                                  | `ClusterIP`                                     |
+| `service.port`               | CodeTogether exposed service port                                             | `80`                                            |
+| `ingress.annotations`        | Specify ingress class                                                         | `{}`                                            |
+| `ingress.enabled`            | Enable ingress controller resource                                            | `false`                                         |
+| `ingress.hosts.paths`        | Paths to match against incoming requests.                                     | `'[{'path': '/'}]`                              |
+| `ingress.hosts`              | Application hostnames                                                         | `chart-example.local`                           |
+| `ingress.tls`                | Ingress TLS configuration                                                     | `[]`                                            |
+| `image.repository`           | Container image repository                                                    | `hub.edge.codetogether.com/latest/codetogether` |
+| `image.pullPolicy`           | Container image pull policy                                                   | `Always`                                        |
+| `image.tag`                  | Container image tag                                                           | `latest`                                        |
+| `imagePullSecrets`           | Specify the secret to use to pull image from repository.                      | `[{'name': 'ctcreds'}]`                                        |
+| `ressources`                 | Pod resource requests & limits                                                | `{}`                                            |
+| `nodeSelector`               | Node labels for pod assignment                                                | `{}`                                            |
+| `toleration`                 | List of node taints to tolerate                                               | `[]`                                            |
+| `affinity`                   | Affinity for pod assignment                                                   | `{}`                                            |
+| `replicaCount`               | Number of replicas                                                            | `1`                                             |
+| `nameOverride`               | Override the release name for object created by Helm                          | `""`                                            |
+| `fullnameOverride`           | Override the fullname for object created by Helm                              | `""`                                            |
+| `serviceAccount.create`      | Whether a new service account name that the agent will use should be created. | `true`                                          |
+| `serviceAccount.annotations` | Annotations to add to the service account                                     | `{}`                                            |
+| `serviceAccount.name`        | Service account to be used.                                                   | `""`                                            |
+| `serverURL`                  | The CodeTogether server URL. Should match the Ingress config, if enabled.     | `http://chart-example.local`                    |
+| `trustAllCerts`              | Allow the use of untrusted certifictates.                                     | `true`                                          |
+| `license.licensee`           | The license provided by Genuitec.                                             | `Example`                                       |
+| `license.maxConnections`     | The maximum connection allowed by the license.                                | `0`                                             |
+| `license.expiration`         | The license expiration date.                                                  | `1970/01/01`                                    |
+| `license.signature`          | The license signature.                                                        | `123456789abcdef`                               |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install my-release \
+  --set replicaCount=2 \
+  --set service.port=8080 \
+  crivaledaz/codetogether
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install my-release -f values.yaml crivaledaz/codetogether
+```
+
+**Note** : This Chart use a container image available on a private repository. You must get credentials from Genuitec to access the repository. To add repository credentials to your cluster, create a secret with the following command :
+
+```bash
+$ kubectl create secret docker-registry ctcreds --docker-server=hub.edge.codetogether.com --docker-username=<provided-username> --docker-password=<provided-password>
+```

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "codetogether.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "codetogether.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "codetogether.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "codetogether.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "codetogether.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "codetogether.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "codetogether.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "codetogether.labels" -}}
+helm.sh/chart: {{ include "codetogether.chart" . }}
+{{ include "codetogether.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "codetogether.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "codetogether.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "codetogether.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "codetogether.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "codetogether.fullname" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "codetogether.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "codetogether.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: CT_LOCATOR
+            value: "none"
+          - name: CT_SERVER_URL
+            value: {{ .Values.serverURL | quote }}
+          - name: CT_TRUST_ALL_CERTS
+            value: {{ .Values.trustAllCerts | quote }}
+          - name: CT_LICENSEE
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "codetogether.fullname" . }}-license
+                key: licensee
+          - name: CT_MAXCONNECTIONS
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "codetogether.fullname" . }}-license
+                key: max_connections
+          - name: CT_EXPIRATION
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "codetogether.fullname" . }}-license
+                key: expiration
+          - name: CT_SIGNATURE
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "codetogether.fullname" . }}-license
+                key: signature
+          ports:
+            - name: http
+              containerPort: 1080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "codetogether.fullname" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "codetogether.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "codetogether.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "codetogether.fullname" . }}-license
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+type: Opaque
+data:
+  licensee: {{ .Values.license.licensee | b64enc | quote }}
+  max_connections: {{ .Values.license.maxConnections | b64enc | quote }}
+  expiration: {{ .Values.license.expiration | b64enc | quote }}
+  signature: {{ .Values.license.signature | b64enc | quote }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "codetogether.fullname" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "codetogether.selectorLabels" . | nindent 4 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "codetogether.serviceAccountName" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "codetogether.fullname" . }}-test-connection"
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "codetogether.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,95 @@
+# Default values for codetogether.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+serverURL: http://chart-example.local
+trustAllCerts: "true"
+
+# Provided by your Genuitec Sales Representative
+# *values must match exactly
+license:
+  licensee: "Example"
+  maxConnections: "0"
+  expiration: "1970/01/01"
+  signature: "123456789abcdef"
+
+image:
+  repository: hub.edge.codetogether.com/latest/codetogether
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets:
+  - name: ctcreds
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        backend:
+          serviceName: chart-example.local
+          servicePort: 80
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This Helm chart allows to deploy a CodeTogether server on premises in a Kubernetes cluster.

This chart is an alternative to the Kubernetes deployment from YAML files, as described [here](https://www.codetogether.com/docs/on-premises-installation-guide/#kubernetes). It tries to industrialize and standardize the deployment using the Kubernetes package manager : Helm.

This Helm chart is a good choice for testing purpose and it is production ready, offering standard Helm integration.

I tested it with an evaluation license on a Kubernetes cluster version 1.18.8 with Helm 3.5.2.